### PR TITLE
feat(example): process field level struct tags

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -310,7 +310,7 @@ func WithPropsFromStructTags(tags reflect.StructTag, fieldType reflect.Type, sch
 		enums := strings.Split(enum, ",")
 		s := make([]interface{}, len(enums))
 		for i, v := range enums {
-			if fieldType.Kind() == reflect.String {
+			if fieldType.Kind() == reflect.String || fieldType.Kind() == reflect.Ptr {
 				s[i] = v
 			} else {
 				iV, _ := strconv.Atoi(v)

--- a/schema.go
+++ b/schema.go
@@ -308,7 +308,6 @@ func WithPropsFromStructTags(tags reflect.StructTag, fieldType reflect.Type, sch
 
 	if enum != "" {
 		enums := strings.Split(enum, ",")
-		// []string is not usable as []any, we need to convert to an array of interfaces first
 		s := make([]interface{}, len(enums))
 		for i, v := range enums {
 			if fieldType.Kind() == reflect.String {
@@ -339,7 +338,9 @@ func (api *API) RegisterModel(model Model, opts ...ModelOpts) (name string, sche
 	// It's known, but not in the schemaset yet.
 	if knownSchema, ok := api.KnownTypes[t]; ok {
 		// Objects, enums, need to be references, so add it into the
-		// list.
+		// list. This does only apply if the enum is defined in go code.
+		// If in go context the field is a primitive type and we only know enums from struct tags
+		// we handle this case differently (at least for now)
 		if !slices.Contains(reflectPrimitives, name) && shouldBeReferenced(&knownSchema) {
 			api.models[name] = &knownSchema
 		}

--- a/schema.go
+++ b/schema.go
@@ -349,8 +349,7 @@ func (api *API) RegisterModel(model Model, opts ...ModelOpts) (name string, sche
 	name = api.getModelName(t)
 
 	if !slices.Contains(reflectPrimitives, name) {
-		var ok bool
-		if schema, ok = api.models[name]; ok {
+		if schema, ok := api.models[name]; ok {
 			return name, schema, nil
 		}
 	}

--- a/schema.go
+++ b/schema.go
@@ -288,22 +288,38 @@ func WithPropsFromStructTags(tags reflect.StructTag, fieldType reflect.Type, sch
 	enum := tags.Get("enums")
 
 	if minimum != "" {
-		min, _ := strconv.Atoi(minimum)
-		schema.WithMin(float64(min))
+		min, err := strconv.Atoi(minimum)
+		if err != nil {
+			fmt.Println("Could not convert minimum value to desired type", err)
+		} else {
+			schema.WithMin(float64(min))
+		}
 	}
 	if maximum != "" {
-		max, _ := strconv.Atoi(maximum)
-		schema.WithMax(float64(max))
+		max, err := strconv.Atoi(maximum)
+		if err != nil {
+			fmt.Println("Could not convert maximum value to desired type", err)
+		} else {
+			schema.WithMax(float64(max))
+		}
 	}
 
 	if minLength != "" {
-		minL, _ := strconv.Atoi(minLength)
-		schema.WithMinLength(int64(minL))
+		minL, err := strconv.Atoi(minLength)
+		if err != nil {
+			fmt.Println("Could not convert minLength value to desired type", err)
+		} else {
+			schema.WithMinLength(int64(minL))
+		}
 	}
 
 	if maxLength != "" {
-		maxL, _ := strconv.Atoi(maxLength)
-		schema.WithMaxLength(int64(maxL))
+		maxL, err := strconv.Atoi(maxLength)
+		if err != nil {
+			fmt.Println("Could not convert maxLength value to desired type", err)
+		} else {
+			schema.WithMaxLength(int64(maxL))
+		}
 	}
 
 	if enum != "" {
@@ -313,8 +329,12 @@ func WithPropsFromStructTags(tags reflect.StructTag, fieldType reflect.Type, sch
 			if fieldType.Kind() == reflect.String || fieldType.Kind() == reflect.Ptr {
 				s[i] = v
 			} else {
-				iV, _ := strconv.Atoi(v)
-				s[i] = iV
+				iV, err := strconv.Atoi(v)
+				if err != nil {
+					fmt.Println("Could not convert enum value to desired type", err)
+				} else {
+					s[i] = iV
+				}
 			}
 		}
 		schema.WithEnum(s...)

--- a/schema_test.go
+++ b/schema_test.go
@@ -202,6 +202,7 @@ type WithExamplesMinMaxEnum struct {
 	Foo string `json:"foo" minLength:"2" maxLength:"5"`
 	Bar int    `json:"bar" minimum:"0" maximum:"255"`
 	Baz string `json:"baz" enums:"foo,bar,baz"`
+	Qux int    `json:"qux" enums:"1,2,3"`
 }
 
 func TestSchema(t *testing.T) {

--- a/schema_test.go
+++ b/schema_test.go
@@ -199,11 +199,13 @@ type WithWithSwaggerType struct {
 }
 
 type WithExamplesMinMaxEnum struct {
-	Foo  string  `json:"foo" minLength:"2" maxLength:"5"`
-	Bar  int     `json:"bar" minimum:"0" maximum:"255"`
-	Baz  string  `json:"baz" enums:"foo,bar,baz"`
-	Qux  int     `json:"qux" enums:"1,2,3"`
-	Fred *string `json:"fred" enums:"foo,bar,baz"`
+	Foo   string  `json:"foo" minLength:"2" maxLength:"5"`
+	Bar   int     `json:"bar" minimum:"0" maximum:"255"`
+	Baz   string  `json:"baz" enums:"foo,bar,baz"`
+	Qux   int     `json:"qux" enums:"1,2,3"`
+	Fred  *string `json:"fred" enums:"foo,bar,baz"`
+	Thud  float64 `json:"thud" minimum:"0" maximum:"9.9999"`
+	Waldo float64 `json:"waldo" minimum:"0" maximum:"99999.9999999"`
 }
 
 func TestSchema(t *testing.T) {

--- a/schema_test.go
+++ b/schema_test.go
@@ -199,10 +199,11 @@ type WithWithSwaggerType struct {
 }
 
 type WithExamplesMinMaxEnum struct {
-	Foo string `json:"foo" minLength:"2" maxLength:"5"`
-	Bar int    `json:"bar" minimum:"0" maximum:"255"`
-	Baz string `json:"baz" enums:"foo,bar,baz"`
-	Qux int    `json:"qux" enums:"1,2,3"`
+	Foo  string  `json:"foo" minLength:"2" maxLength:"5"`
+	Bar  int     `json:"bar" minimum:"0" maximum:"255"`
+	Baz  string  `json:"baz" enums:"foo,bar,baz"`
+	Qux  int     `json:"qux" enums:"1,2,3"`
+	Fred *string `json:"fred" enums:"foo,bar,baz"`
 }
 
 func TestSchema(t *testing.T) {

--- a/schema_test.go
+++ b/schema_test.go
@@ -198,6 +198,12 @@ type WithWithSwaggerType struct {
 	Bar string `json:"bar,omitempty"`
 }
 
+type WithExamplesMinMaxEnum struct {
+	Foo string `json:"foo" minLength:"2" maxLength:"5"`
+	Bar int    `json:"bar" minimum:"0" maximum:"255"`
+	Baz string `json:"baz" enums:"foo,bar,baz"`
+}
+
 func TestSchema(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -445,6 +451,15 @@ func TestSchema(t *testing.T) {
 				api.RegisterModel(ModelOf[StructWithTags](), WithExample(foo))
 				api.Get("/with-model-examples").
 					HasResponseModel(http.StatusOK, ModelOf[StructWithTags]())
+				return
+			},
+		},
+		{
+			name: "with-field-examples-min-max.yaml",
+			setup: func(api *API) (err error) {
+				api.RegisterModel(ModelOf[WithExamplesMinMaxEnum]())
+				api.Get("/with-field-examples-min-max").
+					HasResponseModel(http.StatusOK, ModelOf[WithExamplesMinMaxEnum]())
 				return
 			},
 		},

--- a/tests/custom-models.yaml
+++ b/tests/custom-models.yaml
@@ -1,7 +1,6 @@
 components:
   schemas:
     StructWithCustomisation:
-      nullable: true
       properties:
         a:
           description: A string

--- a/tests/with-field-examples-min-max.yaml
+++ b/tests/with-field-examples-min-max.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+components:
+  schemas:
+    WithExamplesMinMaxEnum:
+      type: object
+      properties:
+        foo:
+          type: string
+          minLength: 2
+          maxLength: 5
+        bar:
+          type: integer
+          minimum: 0
+          maximum: 255
+        baz:
+          type: string
+          enum: [foo, bar, baz]
+      required:
+      - foo
+      - bar
+      - baz
+info:
+  title: with-field-examples-min-max.yaml
+  version: 0.0.0
+paths:
+  /with-field-examples-min-max:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WithExamplesMinMaxEnum'
+          description: ""
+        default:
+          description: ""

--- a/tests/with-field-examples-min-max.yaml
+++ b/tests/with-field-examples-min-max.yaml
@@ -22,11 +22,21 @@ components:
           nullable: true
           type: string
           enum: [foo, bar, baz]
+        thud:
+          type: number
+          minimum: 0
+          maximum: 9.9999
+        waldo:
+          type: number
+          minimum: 0
+          maximum: 99999.9999999
       required:
       - foo
       - bar
       - baz
       - qux
+      - thud
+      - waldo
 info:
   title: with-field-examples-min-max.yaml
   version: 0.0.0

--- a/tests/with-field-examples-min-max.yaml
+++ b/tests/with-field-examples-min-max.yaml
@@ -18,6 +18,10 @@ components:
         qux:
           type: integer
           enum: [1, 2, 3]
+        fred:
+          nullable: true
+          type: string
+          enum: [foo, bar, baz]
       required:
       - foo
       - bar

--- a/tests/with-field-examples-min-max.yaml
+++ b/tests/with-field-examples-min-max.yaml
@@ -15,10 +15,14 @@ components:
         baz:
           type: string
           enum: [foo, bar, baz]
+        qux:
+          type: integer
+          enum: [1, 2, 3]
       required:
       - foo
       - bar
       - baz
+      - qux
 info:
   title: with-field-examples-min-max.yaml
   version: 0.0.0


### PR DESCRIPTION
Enhances model registration to capture struct tags to be used as `minimum/maximum/minLength/maxLength/enum` per field of a schema.