### PR TITLE
fix(schema): Use validate tags instead of json omitempty

### DIFF
--- a/examples/chiexample/go.mod
+++ b/examples/chiexample/go.mod
@@ -1,27 +1,27 @@
 module github.com/heimspiel/rest/examples/chiexample
 
-go 1.21
+go 1.22.0
 
-toolchain go1.22.2
+toolchain go1.23.0
 
 replace github.com/heimspiel/rest v0.0.0 => ../../
 
 require (
 	github.com/a-h/respond v0.0.2
-	github.com/heimspiel/rest v0.0.0
-	github.com/getkin/kin-openapi v0.124.0
+	github.com/getkin/kin-openapi v0.126.0
 	github.com/go-chi/chi/v5 v5.0.12
+	github.com/heimspiel/rest v0.0.0
 )
 
 require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/invopop/yaml v0.2.0 // indirect
+	github.com/invopop/yaml v0.3.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
-	golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0 // indirect
+	golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8 // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/tools v0.20.0 // indirect

--- a/examples/chiexample/go.sum
+++ b/examples/chiexample/go.sum
@@ -4,6 +4,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/getkin/kin-openapi v0.124.0 h1:VSFNMB9C9rTKBnQ/fpyDU8ytMTr4dWI9QovSKj9kz/M=
 github.com/getkin/kin-openapi v0.124.0/go.mod h1:wb1aSZA/iWmorQP9KTAS/phLj/t17B5jT7+fS8ed9NM=
+github.com/getkin/kin-openapi v0.126.0/go.mod h1:7mONz8IwmSRg6RttPu6v8U/OJ+gr+J99qSFNjPGSQqw=
 github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
 github.com/go-chi/chi/v5 v5.0.12/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-openapi/jsonpointer v0.21.0 h1:YgdVicSA9vH5RiHs9TZW5oyafXZFc6+2Vc1rr/O9oNQ=
@@ -16,6 +17,7 @@ github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/invopop/yaml v0.2.0 h1:7zky/qH+O0DwAyoobXUqvVBwgBFRxKoQ/3FjcVpjTMY=
 github.com/invopop/yaml v0.2.0/go.mod h1:2XuRLgs/ouIrW3XNzuNj7J3Nvu/Dig5MXvbCEdiBN3Q=
+github.com/invopop/yaml v0.3.1/go.mod h1:PMOp3nn4/12yEZUFfmOuNHJsZToEEOwoWsT+D81KkeA=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -38,6 +40,7 @@ github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0 h1:985EYyeCOxTpcgOTJpflJUwOeEz0CQOdPt73OzpE9F8=
 golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0/go.mod h1:/lliqkxwWAhPjf5oSOIJup2XcqJaw8RGS6k3TGEc7GI=
+golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8/go.mod h1:/lliqkxwWAhPjf5oSOIJup2XcqJaw8RGS6k3TGEc7GI=
 golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
 golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=

--- a/examples/offline/go.mod
+++ b/examples/offline/go.mod
@@ -1,26 +1,26 @@
 module github.com/heimspiel/rest/examples/offline
 
-go 1.21
+go 1.22.0
 
-toolchain go1.22.2
+toolchain go1.23.0
 
 replace github.com/heimspiel/rest v0.0.0 => ../../
 
 require (
 	github.com/a-h/respond v0.0.2
+	github.com/getkin/kin-openapi v0.126.0
 	github.com/heimspiel/rest v0.0.0
-	github.com/getkin/kin-openapi v0.124.0
 )
 
 require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/invopop/yaml v0.2.0 // indirect
+	github.com/invopop/yaml v0.3.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
-	golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0 // indirect
+	golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8 // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/tools v0.20.0 // indirect

--- a/examples/offline/go.sum
+++ b/examples/offline/go.sum
@@ -4,6 +4,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/getkin/kin-openapi v0.124.0 h1:VSFNMB9C9rTKBnQ/fpyDU8ytMTr4dWI9QovSKj9kz/M=
 github.com/getkin/kin-openapi v0.124.0/go.mod h1:wb1aSZA/iWmorQP9KTAS/phLj/t17B5jT7+fS8ed9NM=
+github.com/getkin/kin-openapi v0.126.0/go.mod h1:7mONz8IwmSRg6RttPu6v8U/OJ+gr+J99qSFNjPGSQqw=
 github.com/go-openapi/jsonpointer v0.21.0 h1:YgdVicSA9vH5RiHs9TZW5oyafXZFc6+2Vc1rr/O9oNQ=
 github.com/go-openapi/jsonpointer v0.21.0/go.mod h1:IUyH9l/+uyhIYQ/PXVA41Rexl+kOkAPDdXEYns6fzUY=
 github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+GrE=
@@ -14,6 +15,7 @@ github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/invopop/yaml v0.2.0 h1:7zky/qH+O0DwAyoobXUqvVBwgBFRxKoQ/3FjcVpjTMY=
 github.com/invopop/yaml v0.2.0/go.mod h1:2XuRLgs/ouIrW3XNzuNj7J3Nvu/Dig5MXvbCEdiBN3Q=
+github.com/invopop/yaml v0.3.1/go.mod h1:PMOp3nn4/12yEZUFfmOuNHJsZToEEOwoWsT+D81KkeA=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -36,6 +38,7 @@ github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0 h1:985EYyeCOxTpcgOTJpflJUwOeEz0CQOdPt73OzpE9F8=
 golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0/go.mod h1:/lliqkxwWAhPjf5oSOIJup2XcqJaw8RGS6k3TGEc7GI=
+golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8/go.mod h1:/lliqkxwWAhPjf5oSOIJup2XcqJaw8RGS6k3TGEc7GI=
 golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
 golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=

--- a/examples/stdlib/go.mod
+++ b/examples/stdlib/go.mod
@@ -1,26 +1,26 @@
 module github.com/heimspiel/rest/examples/stdlib
 
-go 1.21
+go 1.22.0
 
-toolchain go1.22.2
+toolchain go1.23.0
 
 replace github.com/heimspiel/rest v0.0.0 => ../../
 
 require (
 	github.com/a-h/respond v0.0.2
+	github.com/getkin/kin-openapi v0.126.0
 	github.com/heimspiel/rest v0.0.0
-	github.com/getkin/kin-openapi v0.124.0
 )
 
 require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/invopop/yaml v0.2.0 // indirect
+	github.com/invopop/yaml v0.3.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
-	golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0 // indirect
+	golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8 // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/tools v0.20.0 // indirect

--- a/examples/stdlib/go.sum
+++ b/examples/stdlib/go.sum
@@ -4,6 +4,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/getkin/kin-openapi v0.124.0 h1:VSFNMB9C9rTKBnQ/fpyDU8ytMTr4dWI9QovSKj9kz/M=
 github.com/getkin/kin-openapi v0.124.0/go.mod h1:wb1aSZA/iWmorQP9KTAS/phLj/t17B5jT7+fS8ed9NM=
+github.com/getkin/kin-openapi v0.126.0/go.mod h1:7mONz8IwmSRg6RttPu6v8U/OJ+gr+J99qSFNjPGSQqw=
 github.com/go-openapi/jsonpointer v0.21.0 h1:YgdVicSA9vH5RiHs9TZW5oyafXZFc6+2Vc1rr/O9oNQ=
 github.com/go-openapi/jsonpointer v0.21.0/go.mod h1:IUyH9l/+uyhIYQ/PXVA41Rexl+kOkAPDdXEYns6fzUY=
 github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+GrE=
@@ -14,6 +15,7 @@ github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/invopop/yaml v0.2.0 h1:7zky/qH+O0DwAyoobXUqvVBwgBFRxKoQ/3FjcVpjTMY=
 github.com/invopop/yaml v0.2.0/go.mod h1:2XuRLgs/ouIrW3XNzuNj7J3Nvu/Dig5MXvbCEdiBN3Q=
+github.com/invopop/yaml v0.3.1/go.mod h1:PMOp3nn4/12yEZUFfmOuNHJsZToEEOwoWsT+D81KkeA=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -36,6 +38,7 @@ github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0 h1:985EYyeCOxTpcgOTJpflJUwOeEz0CQOdPt73OzpE9F8=
 golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0/go.mod h1:/lliqkxwWAhPjf5oSOIJup2XcqJaw8RGS6k3TGEc7GI=
+golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8/go.mod h1:/lliqkxwWAhPjf5oSOIJup2XcqJaw8RGS6k3TGEc7GI=
 golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
 golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=

--- a/schema.go
+++ b/schema.go
@@ -483,8 +483,10 @@ func (api *API) RegisterModel(model Model, opts ...ModelOpts) (name string, sche
 				fieldName = f.Name
 			}
 
+			validationTags := strings.Split(f.Tag.Get("validate"), ",")
+
 			tempOpts := []ModelOpts{}
-			if len(jsonTags) > 1 && jsonTags[1] == "omitempty" {
+			if slices.Contains(validationTags, "nullable") {
 				tempOpts = append(tempOpts, WithNullable())
 			}
 
@@ -518,7 +520,7 @@ func (api *API) RegisterModel(model Model, opts ...ModelOpts) (name string, sche
 			}
 			schema.Properties[fieldName] = ref
 			isPtr := fieldType.Kind() == reflect.Pointer
-			hasOmitEmptySet := slices.Contains(jsonTags, "omitempty")
+			hasOmitEmptySet := !slices.Contains(validationTags, "required")
 			if isFieldRequired(isPtr, hasOmitEmptySet) {
 				schema.Required = append(schema.Required, fieldName)
 			}

--- a/schema.go
+++ b/schema.go
@@ -518,8 +518,6 @@ func (api *API) RegisterModel(model Model, opts ...ModelOpts) (name string, sche
 			}
 			schema.Properties[fieldName] = ref
 
-			// This removes the need for the omitempty tag, to make the field non required.
-			// Required fields should be provided through a CustomSchemaApplier (https://pkg.go.dev/github.com/a-h/rest#CustomSchemaApplier)
 			//isPtr := fieldType.Kind() == reflect.Pointer
 			//hasOmitEmptySet := slices.Contains(jsonTags, "omitempty")
 			//if isFieldRequired(isPtr, true) {

--- a/schema.go
+++ b/schema.go
@@ -483,10 +483,8 @@ func (api *API) RegisterModel(model Model, opts ...ModelOpts) (name string, sche
 				fieldName = f.Name
 			}
 
-			validationTags := strings.Split(f.Tag.Get("validate"), ",")
-
 			tempOpts := []ModelOpts{}
-			if slices.Contains(validationTags, "omitempty") {
+			if slices.Contains(strings.Split(f.Tag.Get("validate"), ","), "omitempty") {
 				tempOpts = append(tempOpts, WithNullable())
 			}
 
@@ -519,14 +517,14 @@ func (api *API) RegisterModel(model Model, opts ...ModelOpts) (name string, sche
 				}
 			}
 			schema.Properties[fieldName] = ref
-			isPtr := fieldType.Kind() == reflect.Pointer
 
 			// This removes the need for the omitempty tag, to make the field non required.
 			// Required fields should be provided through a CustomSchemaApplier (https://pkg.go.dev/github.com/a-h/rest#CustomSchemaApplier)
+			//isPtr := fieldType.Kind() == reflect.Pointer
 			//hasOmitEmptySet := slices.Contains(jsonTags, "omitempty")
-			if isFieldRequired(isPtr, true) {
-				schema.Required = append(schema.Required, fieldName)
-			}
+			//if isFieldRequired(isPtr, true) {
+			//	schema.Required = append(schema.Required, fieldName)
+			//}
 		}
 	}
 

--- a/schema.go
+++ b/schema.go
@@ -486,7 +486,7 @@ func (api *API) RegisterModel(model Model, opts ...ModelOpts) (name string, sche
 			validationTags := strings.Split(f.Tag.Get("validate"), ",")
 
 			tempOpts := []ModelOpts{}
-			if slices.Contains(validationTags, "nullable") {
+			if slices.Contains(validationTags, "omitempty") {
 				tempOpts = append(tempOpts, WithNullable())
 			}
 
@@ -520,8 +520,11 @@ func (api *API) RegisterModel(model Model, opts ...ModelOpts) (name string, sche
 			}
 			schema.Properties[fieldName] = ref
 			isPtr := fieldType.Kind() == reflect.Pointer
-			hasOmitEmptySet := !slices.Contains(validationTags, "required")
-			if isFieldRequired(isPtr, hasOmitEmptySet) {
+
+			// This removes the need for the omitempty tag, to make the field non required.
+			// Required fields should be provided through a CustomSchemaApplier (https://pkg.go.dev/github.com/a-h/rest#CustomSchemaApplier)
+			//hasOmitEmptySet := slices.Contains(jsonTags, "omitempty")
+			if isFieldRequired(isPtr, true) {
 				schema.Required = append(schema.Required, fieldName)
 			}
 		}

--- a/schema_test.go
+++ b/schema_test.go
@@ -24,10 +24,22 @@ type TestRequestType struct {
 	IntField int
 }
 
+func (m TestRequestType) ApplyCustomSchema(s *openapi3.Schema) {
+	s.Required = []string{
+		"IntField",
+	}
+}
+
 // TestResponseType description.
 type TestResponseType struct {
 	// IntField description.
 	IntField int
+}
+
+func (m TestResponseType) ApplyCustomSchema(s *openapi3.Schema) {
+	s.Required = []string{
+		"IntField",
+	}
 }
 
 type AllBasicDataTypes struct {
@@ -48,6 +60,28 @@ type AllBasicDataTypes struct {
 	Rune    rune
 	String  string
 	Bool    bool
+}
+
+func (m AllBasicDataTypes) ApplyCustomSchema(s *openapi3.Schema) {
+	s.Required = []string{
+		"Int",
+		"Int8",
+		"Int16",
+		"Int32",
+		"Int64",
+		"Uint",
+		"Uint8",
+		"Uint16",
+		"Uint32",
+		"Uint64",
+		"Uintptr",
+		"Float32",
+		"Float64",
+		"Byte",
+		"Rune",
+		"String",
+		"Bool",
+	}
 }
 
 type AllBasicDataTypesPointers struct {
@@ -72,25 +106,52 @@ type AllBasicDataTypesPointers struct {
 
 type OmitEmptyFields struct {
 	A string
-	B string `json:",omitempty"`
+	B string `validate:",omitempty"`
 	C *string
-	D *string `json:",omitempty"`
+	D *string `validate:",omitempty"`
+}
+
+func (m OmitEmptyFields) ApplyCustomSchema(s *openapi3.Schema) {
+	s.Required = []string{
+		"A",
+	}
 }
 
 type EmbeddedStructA struct {
 	A string
 }
+
+func (m EmbeddedStructA) ApplyCustomSchema(s *openapi3.Schema) {
+	s.Required = []string{
+		"A",
+	}
+}
+
 type EmbeddedStructB struct {
 	B                string
-	OptionalB        string `json:",omitempty"`
+	OptionalB        string `validate:",omitempty"`
 	PointerB         *string
-	OptionalPointerB *string `json:",omitempty"`
+	OptionalPointerB *string `validate:",omitempty"`
+}
+
+func (m EmbeddedStructB) ApplyCustomSchema(s *openapi3.Schema) {
+	s.Required = []string{
+		"B",
+	}
 }
 
 type WithEmbeddedStructs struct {
 	EmbeddedStructA
 	EmbeddedStructB
 	C string
+}
+
+func (m WithEmbeddedStructs) ApplyCustomSchema(s *openapi3.Schema) {
+	s.Required = []string{
+		"A",
+		"B",
+		"C",
+	}
 }
 
 type WithNameStructTags struct {
@@ -106,9 +167,24 @@ type WithNameStructTags struct {
 	MiddleName string
 }
 
+func (m WithNameStructTags) ApplyCustomSchema(s *openapi3.Schema) {
+	s.Required = []string{
+		"firstName",
+		"LastName",
+		"FullName",
+		"MiddleName",
+	}
+}
+
 type KnownTypes struct {
 	Time    time.Time  `json:"time"`
 	TimePtr *time.Time `json:"timePtr"`
+}
+
+func (m KnownTypes) ApplyCustomSchema(s *openapi3.Schema) {
+	s.Required = []string{
+		"time",
+	}
 }
 
 type User struct {
@@ -116,8 +192,21 @@ type User struct {
 	Name string `json:"name"`
 }
 
+func (m User) ApplyCustomSchema(s *openapi3.Schema) {
+	s.Required = []string{
+		"id",
+		"name",
+	}
+}
+
 type OK struct {
 	OK bool `json:"ok"`
+}
+
+func (m OK) ApplyCustomSchema(s *openapi3.Schema) {
+	s.Required = []string{
+		"ok",
+	}
 }
 
 type StringEnum string
@@ -143,10 +232,25 @@ type WithEnums struct {
 	V  string       `json:"v"`
 }
 
+func (m WithEnums) ApplyCustomSchema(s *openapi3.Schema) {
+	s.Required = []string{
+		"s",
+		"ss",
+		"i",
+		"v",
+	}
+}
+
 type Pence int64
 
 type WithMaps struct {
 	Amounts map[string]Pence `json:"amounts"`
+}
+
+func (m WithMaps) ApplyCustomSchema(s *openapi3.Schema) {
+	s.Required = []string{
+		"amounts",
+	}
 }
 
 type MultipleDateFieldsWithComments struct {
@@ -154,6 +258,13 @@ type MultipleDateFieldsWithComments struct {
 	DateField time.Time `json:"dateField"`
 	// DateFieldA is another field containing a date
 	DateFieldA time.Time `json:"dateFieldA"`
+}
+
+func (m MultipleDateFieldsWithComments) ApplyCustomSchema(s *openapi3.Schema) {
+	s.Required = []string{
+		"dateField",
+		"dateFieldA",
+	}
 }
 
 type StructWithCustomisation struct {
@@ -166,6 +277,10 @@ func (*StructWithCustomisation) ApplyCustomSchema(s *openapi3.Schema) {
 	s.Properties["a"].Value.Description = "A string"
 	s.Properties["a"].Value.Example = "test"
 	s.Properties["b"].Value.Description = "A custom field"
+	s.Required = []string{
+		"a",
+		"b",
+	}
 }
 
 type FieldWithCustomisation string
@@ -179,23 +294,29 @@ type StructWithTags struct {
 	A string `json:"a" rest:"A is a string."`
 }
 
+func (m StructWithTags) ApplyCustomSchema(s *openapi3.Schema) {
+	s.Required = []string{
+		"a",
+	}
+}
+
 type RecursiveModelModel struct {
-	Model *RecursiveModel `json:"model,omitempty"`
-	Bar   string          `json:"bar,omitempty"`
+	Model *RecursiveModel `json:"model" validate:"omitempty"`
+	Bar   string          `json:"bar" validate:"omitempty"`
 }
 
 type RecursiveModel struct {
-	Recursive *RecursiveModelModel `json:"recursive,omitempty"`
-	Foo       string               `json:"foo,omitempty"`
+	Recursive *RecursiveModelModel `json:"recursive" validate:"omitempty"`
+	Foo       string               `json:"foo" validate:"omitempty"`
 }
 
 type WithSwaggerType struct {
-	Foo []uint8 `json:"foo,omitempty" swaggertype:"string"`
+	Foo []uint8 `json:"foo" swaggertype:"string" validate:"omitempty"`
 }
 
 type WithWithSwaggerType struct {
 	*WithSwaggerType
-	Bar string `json:"bar,omitempty"`
+	Bar string `json:"bar" validate:"omitempty"`
 }
 
 type WithExamplesMinMaxEnumSet struct {
@@ -207,6 +328,18 @@ type WithExamplesMinMaxEnumSet struct {
 	Thud  float64 `json:"thud" minimum:"0" maximum:"9.9999"`
 	Waldo float64 `json:"waldo" minimum:"0" maximum:"99999.9999999"`
 	Set   string  `json:"set" set:"foo,bar"`
+}
+
+func (m WithExamplesMinMaxEnumSet) ApplyCustomSchema(s *openapi3.Schema) {
+	s.Required = []string{
+		"foo",
+		"bar",
+		"baz",
+		"qux",
+		"thud",
+		"waldo",
+		"set",
+	}
 }
 
 func TestSchema(t *testing.T) {

--- a/tests/anonymous-type.yaml
+++ b/tests/anonymous-type.yaml
@@ -6,15 +6,11 @@ components:
       properties:                            
         A:   
           type: string                                                                            
-      required:
-      - A
     AnonymousType1: 
       type: object
       properties:
         B:
-          type: string        
-      required:
-      - B
+          type: string
 info:           
   title: anonymous-type.yaml             
   version: 0.0.0   


### PR DESCRIPTION
This changes the schema generation to listen to the `validation` tag instead of the `json` tag. This is needed since we don't want to omit values like `0` and `""` from the response of the API, but still want to validate the requests beforehand.

[Issue](https://github.com/heimspiel/go-dragon-utils/issues/75)